### PR TITLE
Add context for gray background of output_text_verbatim

### DIFF
--- a/shiny/ui/_output.py
+++ b/shiny/ui/_output.py
@@ -277,7 +277,7 @@ def output_code(id: str, placeholder: bool = True) -> Tag:
     Create a output container for code (monospaced text).
 
     This is similar to :func:`~shiny.ui.output_text`, except that it displays the text
-    in a fixed-width container with a gray-ish background color and border.
+    in a Bootstrap well; a fixed-width container with a gray-ish background color and border.
 
     Parameters
     ----------


### PR DESCRIPTION
The existing description of output_text_verbatim says the output element is fixed-width with a gray background but does not explain this comes from Bootstrap.